### PR TITLE
fix "edit this page" links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/sqfmi/beepberry-docs/blob/main/',
         },
         blog: false,
         theme: {


### PR DESCRIPTION
right now, "edit this page" links are broken, since they link to the to `facebook/docusaurus` repo

see at the bottom of [this page](https://beepberry.sqfmi.com/docs/getting-started) for example (and all doc pages)

this PR fixes the "edit this page" url prefix to link to this (`beepberry-docs`) repo