### PR TITLE
README: Add project description + link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Website
+# Technical documentation for SQFMI Beepy
+
+Documentation site for the SQFMI Beepy. Beepy is a portable computing device,
+with a high contrast, high resolution display, and a tactile keyboard +
+touchpad powered by Raspberry Pi Zero W (or any other compatible SBC).
+
+To see the live version of this documentation visit
+[beepy.sqfmi.com/docs/getting-started](https://beepy.sqfmi.com/docs/getting-started).
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 


### PR DESCRIPTION
I landed in the GitHub README before landing on the actual website. The information I've added would have helped me orient myself and get started faster.

- Add a link from README to the live website for ease of navigation.
- Change title from "Website" to "Technical documentation for SQFMI Beepy"
- Add a project description (mostly stolen from the FAQ)