### PR TITLE
add some documentation about mono_cutoff

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,3 +43,9 @@ The Pi Zero W only supports 2.4GHz WiFi networks. Make sure you're not trying to
 ### I prefer a white background with black text
 
 You can invert the display mode by running `echo 1 | sudo tee /sys/module/sharp_drm/parameters/mono_invert`
+
+### My display contrast is too low
+
+You can modify the display constrast by changing the value in `/sys/module/sharp_drm/parameters/mono_cutoff` - the default is 32.
+
+If this is your first time booting up and you see a mostly blank screen with a vague raspberry shape in the top left and some scattered patches of black towards the middle then your image is probably set to boot into the desktop environment. You can make the desktop more legible by setting a `mono_cutoff` of `195` or disable it through `raspi-config`.


### PR DESCRIPTION
In a fit of not paying attention I flashed a full desktop image instead of the lite image - I figured it might be helpful for other folks if the `mono_cutoff` setting was mentioned in the FAQ so they can try to fiddle with it if the screen is showing something weird.