### PR TITLE
Added additional information on which Raspberry Pi image to select

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ There are two choices of operating systems to run on your Beepy
 
 ### Setting up a Raspbian System
 
-1. Use the [Raspberry Pi Imager tool](https://www.raspberrypi.com/software/) to flash an SD card with the Raspberry Pi OS ***Lite*** image
+1. Use the [Raspberry Pi Imager tool](https://www.raspberrypi.com/software/) to flash an SD card with the Raspberry Pi OS ***Lite*** image ***with no desktop environment***
     - Choose OS - Raspberry Pi OS (other) - ***Raspberry Pi OS Lite (32-bit) image***
     - Click the gear icon ⚙ (or press ```CTRL + SHIFT + X```) to set the username, password, hostname, WiFi, and enable SSH
     - Make sure your computer and the Pi are on the same WiFi network in order to SSH in later


### PR DESCRIPTION
Came across an issue where I installed the version of Raspberry Pi with a desktop environment, instead on the CLI version. 

Appended 
> with no desktop environment 

to the getting started guide so following users don't do something similar. 